### PR TITLE
Add Vultr provider

### DIFF
--- a/vultr/LICENSE
+++ b/vultr/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Alexandre Oliveira, CSIRO / Sven Dowideit (libdns/digitalocean)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vultr/README.md
+++ b/vultr/README.md
@@ -1,0 +1,88 @@
+# Vultr for `libdns`
+
+
+This package implements the libdns interfaces for the [Vultr API](https://www.vultr.com/api/) (using the Go library client from: https://github.com/vultr/govultr)
+
+## Authenticating
+
+To authenticate you need to supply a Vultr API token.
+
+## Example
+
+Here's a minimal example of how to get all your DNS records using this `libdns` provider (see `_example/main.go`)
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/libdns/libdns"
+	"github.com/libdns/vultr"
+)
+
+func main() {
+	token := os.Getenv("VULTR_API_TOKEN")
+	if token == "" {
+		fmt.Printf("VULTR_API_TOKEN not set\n")
+		return
+	}
+	zone := os.Getenv("ZONE")
+	if zone == "" {
+		fmt.Printf("ZONE not set\n")
+		return
+	}
+	provider := vultr.Provider{APIToken: token}
+
+	records, err := provider.GetRecords(context.TODO(), zone)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+	}
+
+	testName := "libdns-test"
+	testId := ""
+	for _, record := range records {
+		fmt.Printf("%s (.%s): %s, %s\n", record.Name, zone, record.Value, record.Type)
+		if record.Name == testName {
+			testId = record.ID
+		}
+
+	}
+
+	if testId != "" {
+		// fmt.Printf("Delete entry for %s (id:%s)\n", testName, testId)
+		// _, err = provider.DeleteRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
+		// 	ID: testId,
+		// }})
+		// if err != nil {
+		// 	fmt.Printf("ERROR: %s\n", err.Error())
+		// }
+		// Set only works if we have a record.ID
+		fmt.Printf("Replacing entry for %s\n", testName)
+		_, err = provider.SetRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
+			Type:  "TXT",
+			Name:  testName,
+			Value: fmt.Sprintf("\"Replacement test entry created by libdns %s\"", time.Now()),
+			TTL:   time.Duration(30) * time.Second,
+			ID:    testId,
+		}})
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+		}
+	} else {
+		fmt.Printf("Creating new entry for %s\n", testName)
+		_, err = provider.AppendRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
+			Type:  "TXT",
+			Name:  testName,
+			Value: fmt.Sprintf("\"This is a test entry created by libdns %s\"", time.Now()),
+			TTL:   time.Duration(30) * time.Second,
+		}})
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+		}
+	}
+}
+```

--- a/vultr/_example/main.go
+++ b/vultr/_example/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/libdns/libdns"
+
+	"github.com/libdns/vultr"
+)
+
+func main() {
+	token := os.Getenv("VULTR_API_TOKEN")
+	if token == "" {
+		fmt.Printf("VULTR_API_TOKEN not set\n")
+		return
+	}
+	zone := os.Getenv("ZONE")
+	if zone == "" {
+		fmt.Printf("ZONE not set\n")
+		return
+	}
+
+	provider := vultr.Provider{APIToken: token}
+
+	records, err := provider.GetRecords(context.TODO(), zone)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+	}
+
+	testName := "libdns-test"
+	testId := ""
+	for _, record := range records {
+		fmt.Printf("%s (.%s): %s, %s\n", record.Name, zone, record.Value, record.Type)
+		if record.Name == testName {
+			testId = record.ID
+		}
+	}
+
+
+	if testId != "" {
+		// fmt.Printf("Delete entry for %s (id:%s)\n", testName, testId)
+		// _, err = provider.DeleteRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
+		// 	ID: testId,
+		// }})
+		// if err != nil {
+		// 	fmt.Printf("ERROR: %s\n", err.Error())
+		// }
+		// Set only works if we have a record.ID
+		fmt.Printf("Replacing entry for %s\n", testName)
+		_, err = provider.SetRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
+			Type:  "TXT",
+			Name:  testName,
+			Value: fmt.Sprintf("\"Replacement test entry created by libdns %s\"", time.Now()),
+			TTL:   time.Duration(30) * time.Second,
+			ID:    testId,
+		}})
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+		}
+	} else {
+		fmt.Printf("Creating new entry for %s\n", testName)
+		_, err = provider.AppendRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
+			Type:  "TXT",
+			Name:  testName,
+			Value: fmt.Sprintf("\"This is a test entry created by libdns %s\"", time.Now()),
+			TTL:   time.Duration(30) * time.Second,
+		}})
+		if err != nil {
+			fmt.Printf("ERROR: %s\n", err.Error())
+		}
+	}
+}

--- a/vultr/client.go
+++ b/vultr/client.go
@@ -1,0 +1,105 @@
+package vultr
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/vultr/govultr"
+	"github.com/libdns/libdns"
+)
+
+type Client struct {
+	client *govultr.Client
+	mutex	sync.Mutex
+}
+
+func (p *Provider) getClient() error {
+	if p.client == nil { 
+		p.client = govultr.NewClient(nil, p.APIToken)
+	}
+
+	return nil
+}
+
+func (p *Provider) getDNSEntries(ctx context.Context, domain string) ([]libdns.Record, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.getClient()
+
+	var records []libdns.Record
+	dns_entries, err := p.client.DNSRecord.List(ctx, domain)
+	if err != nil {
+		return records, err
+	}
+
+	for _, entry := range dns_entries {
+		record := libdns.Record{
+			Name: entry.Name,
+			Value: entry.Data,
+			Type:	entry.Type,
+			TTL:	time.Duration(entry.TTL) * time.Second,
+			ID:		strconv.Itoa(entry.RecordID),
+		}
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+func (p *Provider) addDNSRecord(ctx context.Context, domain string, record libdns.Record) (libdns.Record, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.getClient()
+
+	err := p.client.DNSRecord.Create(ctx, domain, record.Type, record.Name, record.Value, int(record.TTL.Seconds()), 0)
+	if err != nil {
+		return record, err
+	}
+
+	return record, nil
+}
+
+func (p *Provider) removeDNSRecord(ctx context.Context, domain string, record libdns.Record) (libdns.Record, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.getClient()
+
+	err := p.client.DNSRecord.Delete(ctx, domain, record.ID)
+	if err != nil {
+		return record, err
+	}
+
+	return record, nil
+}
+
+func (p *Provider) updateDNSRecord(ctx context.Context, domain string, record libdns.Record) (libdns.Record, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	p.getClient()
+
+	id, err := strconv.Atoi(record.ID)
+	if err != nil {
+		return record, err
+	}
+
+	entry := govultr.DNSRecord{
+		Name: record.Name,
+		Data: record.Value,
+		Type: record.Type,
+		TTL: int(record.TTL.Seconds()),
+		RecordID: id,
+	}
+
+	err = p.client.DNSRecord.Update(ctx, domain, &entry)
+	if err != nil {
+		return record, err
+	}
+
+	return record, nil
+}

--- a/vultr/go.mod
+++ b/vultr/go.mod
@@ -1,0 +1,8 @@
+module example.org/libdns/vultr
+
+go 1.15
+
+require (
+	github.com/libdns/libdns v0.1.0
+	github.com/vultr/govultr v1.0.0
+)

--- a/vultr/go.sum
+++ b/vultr/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.7 h1:8/CAEZt/+F7kR7GevNHulKkUjLht3CPmn7egmhieNKo=
+github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/libdns/libdns v0.1.0 h1:0ctCOrVJsVzj53mop1angHp/pE3hmAhP7KiHvR0HD04=
+github.com/libdns/libdns v0.1.0/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/vultr/govultr v1.0.0 h1:yeJrYp9wyA4xXaQZ7eOL2u1wKn2JU79HjRevwvpxbJ4=
+github.com/vultr/govultr v1.0.0/go.mod h1:wZZXZbYbqyY1n3AldoeYNZK4Wnmmoq6dNFkvd5TV3ss=

--- a/vultr/provider.go
+++ b/vultr/provider.go
@@ -1,0 +1,92 @@
+package vultr
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
+// Provider implements the libdns interfaces for Vultr
+// Adapted from libdns/digitalocean to work with the Vultr API
+type Provider struct {
+	Client
+	// APIToken is the Vultr API token
+	// see https://my.vultr.com/settings/#settingsapi
+	APIToken string `json:"auth_token"`
+}
+
+// unFQDN trims any trailing "." from fqdn.
+func (p *Provider) unFQDN(fqdn string) string {
+	return strings.TrimSuffix(fqdn, ".")
+}
+
+// GetRecords lists all the records in the zone.
+func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
+	records, err := p.getDNSEntries(ctx, p.unFQDN(zone))
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+// AppendRecords adds records to the zone. It returns the records that were added.
+func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	var appendedRecords []libdns.Record
+
+	for _, record := range records {
+		newRecord, err := p.addDNSRecord(ctx, p.unFQDN(zone), record)
+		if err != nil {
+			return nil, err
+		}
+		newRecord.TTL = time.Duration(newRecord.TTL) * time.Second
+		appendedRecords = append(appendedRecords, newRecord)
+	}
+
+	return appendedRecords, nil
+}
+
+// DeleteRecords deletes the records from the zone.
+func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	var deletedRecords []libdns.Record
+
+	for _, record := range records {
+		deletedRecord, err := p.removeDNSRecord(ctx, p.unFQDN(zone), record)
+		if err != nil {
+			return nil, err
+		}
+		deletedRecord.TTL = time.Duration(deletedRecord.TTL) * time.Second
+		deletedRecords = append(deletedRecords, deletedRecord)
+	}
+
+	return deletedRecords, nil
+}
+
+// SetRecords sets the records in the zone, either by updating existing records
+// or creating new ones. It returns the updated records.
+func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	var setRecords []libdns.Record
+
+	for _, record := range records {
+		// TODO: if there is no ID, look up the Name, and fill it in, or call
+		//       newRecord, err := p.addDNSEntry(ctx, zone, record)
+		setRecord, err := p.updateDNSRecord(ctx, p.unFQDN(zone), record)
+		if err != nil {
+			return setRecords, err
+		}
+		setRecord.TTL = time.Duration(setRecord.TTL) * time.Second
+		setRecords = append(setRecords, setRecord)
+	}
+
+	return setRecords, nil
+}
+
+// Interface guards
+var (
+	_ libdns.RecordGetter   = (*Provider)(nil)
+	_ libdns.RecordAppender = (*Provider)(nil)
+	_ libdns.RecordSetter   = (*Provider)(nil)
+	_ libdns.RecordDeleter  = (*Provider)(nil)
+)


### PR DESCRIPTION
Related issue: #20 

I've used the existing DigitalOcean provider as a base for this one and it was easy to make it work. There's a catch, however, that the content of the DNS record must be enclosed in quotes in Vultr, so I don't know if this is an issue for libdns.