### PR TITLE
Add deSEC provider implementation

### DIFF
--- a/desec/LICENSE
+++ b/desec/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Florian Zenker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/desec/README.md
+++ b/desec/README.md
@@ -1,0 +1,24 @@
+deSEC for [`libdns`](https://github.com/libdns/libdns)
+======================================================
+
+[![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/desec)
+
+This package implements the [libdns interfaces](https://github.com/libdns/libdns) for
+[deSEC](https://desec.io).
+
+## Authentication
+
+Authentication performed using a token created on https://desec.io/tokens. A basic token without the
+permission to manage tokens is sufficient. For security reasons it's strongly recommended to not use
+tokens that allow token management.
+
+## Limitations and Caveats
+
+* Concurrent updates from multiple processes can result in an inconsistent state
+* The TTL attribute is not settable per record (zone, name, type, value), only per record set (zone,
+  name, type). If different TTL values are specified, it's undefined which one wins.
+* Large zones with more than 500 resource record sets only have limited support
+* Rate limiting always results in retries if no context deadline is specified
+
+Please refer to the [Go reference](https://pkg.go.dev/github.com/libdns/desec) for
+detailed documentation.

--- a/desec/go.mod
+++ b/desec/go.mod
@@ -1,0 +1,9 @@
+module github.com/libdns/desec
+
+go 1.18
+
+require (
+	github.com/google/go-cmp v0.5.9
+	github.com/libdns/libdns v0.2.1
+	golang.org/x/exp v0.0.0-20230420155640-133eef4313cb
+)

--- a/desec/go.sum
+++ b/desec/go.sum
@@ -1,0 +1,6 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
+github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+golang.org/x/exp v0.0.0-20230420155640-133eef4313cb h1:rhjz/8Mbfa8xROFiH+MQphmAmgqRM0bOMnytznhWEXk=
+golang.org/x/exp v0.0.0-20230420155640-133eef4313cb/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/desec/provider.go
+++ b/desec/provider.go
@@ -1,0 +1,570 @@
+// Package desec implements a DNS record management client compatible with the libdns interfaces for
+// [deSEC].
+//
+// # Updates are not atomic
+//
+// The deSEC API doesn't map 1:1 to the libdns API. The main issue with that is that it's not
+// possible to update records atomically. The implementation here goes to great lengths to avoid
+// interference of multiple concurrent requests, but that only works within a single process.
+//
+// If multiple processes are modifying a deSEC zone concurrently, care must be taken that the
+// different processes operate on different [resource record sets]. Otherwise multiple concurrent
+// operations will override one another. The easiest way to protect against that is to use different
+// names within the zone for different processes.
+//
+// If multiple processes operate on the same resource record set, it's possible for two concurrently
+// running writes to result in inconsistent records.
+//
+// # TTL attribute
+//
+// For a the same reason as above, the  TTL attribute cannot be set on the per record level. If
+// multiple different TTLs are specified for different records of the same name and type, one of
+// them wins. It's not defined which on that is.
+//
+// # Large zones (> 500 resource record sets)
+//
+// deSEC requires the use of pagination for zones with more than 500 RRSets. This is a reasonable
+// limit for a general purpose library like libdns and no effort is made to handle zones with more
+// than 500 RRSets. Methods that can fail with more than 500 RRSets have a godoc comment explaining
+// this.
+//
+// # Rate Limiting
+//
+// deSEC applies [rate limiting], this implementation will retry when running into a rate limit
+// while observing context cancellation. In practice this means that calls to methods of this
+// provider can take multiple seconds and longer. It's therefore very important to set a deadline in
+// the context.
+//
+// [deSEC]: http://desec.io
+// [resource record sets]: https://desec.readthedocs.io/en/latest/dns/rrsets.html
+// [rate limiting]: https://desec.readthedocs.io/en/latest/rate-limits.html
+package desec
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/libdns/libdns"
+	"golang.org/x/exp/slices"
+)
+
+// writeToken is used to synchronize all writes to deSEC to make sure the API here adheres to the
+// libdns contract. This is necessary because libdns operates in units of records (zone, name, type,
+// value) while deSEC operates in units of record sets (zone, name, type). This makes it necessary
+// to perform read-modify cycles that can't be done atomically due to limitations in the deSEC API.
+//
+// This also can't be a mutex, because the time it takes to perform a write is theoretically
+// unbounded due to rate limiting (https://desec.readthedocs.io/en/latest/rate-limits.html) and
+// using a mutex here would make it impossible to adhere to context cancellation.
+//
+// Rate limiting on the deSEC side also means that this is unlikely to become a bottleneck, though
+// use cases may exist that cause this single synchronization point to become one.
+var writeToken = make(chan struct{}, 1)
+
+func acquireWriteToken(ctx context.Context) error {
+	select {
+	case <-writeToken:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func releaseWriteToken() {
+	writeToken <- struct{}{}
+}
+
+func init() {
+	writeToken <- struct{}{}
+}
+
+// Provider facilitates DNS record manipulation with deSEC.
+type Provider struct {
+	// Token is a token created on https://desec.io/tokens. A basic token without the permission
+	// to manage tokens is sufficient.
+	Token string `json:"token,omitempty"`
+}
+
+// GetRecords lists all the records in the zone.
+//
+// Caveat: This method will fail if there are more than 500 RRsets in the zone. See package
+// documentation for more detail.
+func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
+	// https://desec.readthedocs.io/en/latest/dns/rrsets.html#retrieving-all-rrsets-in-a-zone
+	rrsets, err := p.listRRSets(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+	var records []libdns.Record
+	for _, rrset := range rrsets {
+		records0, err := libdnsRecords(rrset)
+		if err != nil {
+			return nil, fmt.Errorf("parsing RRSet: %v", err)
+		}
+		records = append(records, records0...)
+	}
+	return records, nil
+}
+
+// AppendRecords adds records to the zone. It returns the records that were added.
+func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	err := acquireWriteToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for inflight requests to finish: %v", err)
+	}
+	defer releaseWriteToken()
+
+	rrsets := make(map[rrKey]*rrSet)
+
+	// Fetch or create base rrsets to append to
+	for _, r := range records {
+		key := rrKey{rrSetSubname(r), r.Type}
+		if _, ok := rrsets[key]; ok {
+			continue
+		}
+
+		rrset, err := p.getRRSet(ctx, zone, key)
+		switch {
+		case errors.Is(err, errNotFound):
+			// no RRSet exists, create one
+			rrset = rrSet{
+				Subname: key.Subname,
+				Type:    key.Type,
+				Records: nil,
+				TTL:     int(r.TTL / time.Second),
+			}
+		case err != nil:
+			return nil, fmt.Errorf("retrieving RRSet: %v", err)
+		}
+		rrsets[key] = &rrset
+	}
+
+	// Merge records into base
+	dirty := make(map[rrKey]struct{})
+	var ret []libdns.Record
+	for _, r := range records {
+		key := rrKey{rrSetSubname(r), r.Type}
+		rrset := rrsets[key]
+
+		v := rrSetRecord(r)
+		if slices.Contains(rrset.Records, v) {
+			// Don't modify existing records, if all records in a record set already exist, the
+			// record set will not be marked dirty and excluded from the update request.
+			continue
+		}
+
+		rrset.Records = append(rrset.Records, v)
+		ret = append(ret, libdns.Record{
+			Name:     r.Name,
+			Type:     r.Type,
+			Value:    r.Value,
+			TTL:      time.Duration(rrset.TTL) * time.Second,
+			Priority: r.Priority,
+			Weight:   r.Weight,
+		})
+
+		// Mark this key as dirty, only dirty keys will result in an update.
+		dirty[key] = struct{}{}
+	}
+
+	update := make([]rrSet, 0, len(dirty))
+	for key := range dirty {
+		update = append(update, *rrsets[key])
+	}
+	if err := p.putRRSets(ctx, zone, update); err != nil {
+		return nil, fmt.Errorf("writing RRSets: %v", err)
+	}
+	return ret, nil
+}
+
+// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
+// It returns the updated records.
+//
+// Caveat: This method will fail if there are more than 500 RRsets in the zone. See package
+// documentation for more detail.
+func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	err := acquireWriteToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for inflight requests to finish: %v", err)
+	}
+	defer releaseWriteToken()
+
+	// Build the desired state
+	rrsets := make(map[rrKey]*rrSet)
+	for _, r := range records {
+		key := rrKey{rrSetSubname(r), r.Type}
+		rrset := rrsets[key]
+		if rrset == nil {
+			rrset = &rrSet{
+				Subname: key.Subname,
+				Type:    key.Type,
+				Records: nil,
+				TTL:     int(r.TTL / time.Second),
+			}
+			rrsets[key] = rrset
+		}
+		rrset.Records = append(rrset.Records, rrSetRecord(r))
+	}
+
+	// Fetch existing rrSets and compare to desired state
+	existing, err := p.listRRSets(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("listing RRSets: %v", err)
+	}
+	for _, g := range existing {
+		key := rrKey{g.Subname, g.Type}
+		w := rrsets[key]
+		switch {
+		case w == nil:
+			// rrset exists, but not in the input, delete it by adding it to rrsets and set
+			// records to an empty slice to represent the deletion.
+			// See https://desec.readthedocs.io/en/latest/dns/rrsets.html#deleting-an-rrset
+			w0 := g
+			w0.Records = []string{}
+			rrsets[key] = &w0
+		case g.equal(w):
+			// rrset exists and is equal to the one we want; skip it in the update.
+			delete(rrsets, key)
+		}
+	}
+
+	// Generate updates to arrive at desired state.
+	update := make([]rrSet, 0, len(rrsets))
+	var ret []libdns.Record
+	for _, rrset := range rrsets {
+		update = append(update, *rrset)
+
+		// Add all records being set here. This ignores records that are being deleted, because
+		// those are represented as an rrset without any records.
+		records0, err := libdnsRecords(*rrset)
+		if err != nil {
+			return nil, fmt.Errorf("parsing RRSet: %v", err)
+		}
+		ret = append(ret, records0...)
+	}
+
+	if err := p.putRRSets(ctx, zone, update); err != nil {
+		return nil, fmt.Errorf("writing RRSets: %v", err)
+	}
+	return ret, nil
+}
+
+// DeleteRecords deletes the records from the zone. It returns the records that were deleted.
+func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	err := acquireWriteToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for inflight requests to finish: %v", err)
+	}
+	defer releaseWriteToken()
+
+	rrsets := make(map[rrKey]*rrSet)
+	dirty := make(map[rrKey]struct{})
+	var ret []libdns.Record
+
+	// Fetch rrsets with records requested for deletion.
+	for _, r := range records {
+		key := rrKey{rrSetSubname(r), r.Type}
+		rrset := rrsets[key]
+		if rrset == nil {
+			rrset0, err := p.getRRSet(ctx, zone, key)
+			switch {
+			case errors.Is(err, errNotFound):
+				continue
+			case err != nil:
+				return nil, fmt.Errorf("retrieving RRSet: %v", err)
+			}
+			rrsets[key] = &rrset0
+			rrset = &rrset0
+		}
+
+		// Delete the record if it exists and mark the rrset as dirty, only dirty rrsets will be
+		// updated.
+		v := rrSetRecord(r)
+		if i := slices.Index(rrset.Records, v); i >= 0 {
+			rrset.Records = slices.Delete(rrset.Records, i, i+1)
+			dirty[key] = struct{}{}
+			ret = append(ret, r)
+		}
+	}
+
+	update := make([]rrSet, 0, len(dirty))
+	for key := range dirty {
+		update = append(update, *rrsets[key])
+	}
+	if err := p.putRRSets(ctx, zone, update); err != nil {
+		return nil, fmt.Errorf("writing RRSets: %v", err)
+	}
+	return ret, nil
+}
+
+// https://desec.readthedocs.io/en/latest/dns/rrsets.html#rrset-field-reference
+type rrSet struct {
+	Subname string   `json:"subname"`
+	Type    string   `json:"type"`
+	Records []string `json:"records"`
+	TTL     int      `json:"ttl,omitempty"`
+}
+
+// rrKey uniquely identifies an rrSet within a zone.
+type rrKey struct {
+	Subname string
+	Type    string
+}
+
+func (rrs *rrSet) equal(other *rrSet) bool {
+	return rrs.Subname == other.Subname && rrs.Type == other.Type && rrs.TTL == other.TTL && slices.Equal(rrs.Records, other.Records)
+}
+
+// libdnsName returns the rrSet subname converted to libdns conventions.
+//
+// deSEC represents the zone itself using an empty (or missing) subname, libdns
+// uses "@"
+func libdnsName(rrs rrSet) string {
+	if rrs.Subname == "" {
+		return "@"
+	}
+	return rrs.Subname
+}
+
+// rrSetSubname returns the libdns name converted to deSEC conventions.
+//
+// deSEC represents the zone itself using an empty (or missing) subname, libdns
+// uses "@"
+func rrSetSubname(r libdns.Record) string {
+	// deSEC represents the zone itself using an empty (or missing) subname, libdns
+	// uses "@"
+	if r.Name == "@" {
+		return ""
+	}
+	return r.Name
+}
+
+// libdnsValue returns the value of the i-th record in libdns conventions
+//
+// libdns provides priority and weight for DNS entries that support it, the list is
+// documented in the libdns.Record documentation.
+func libdnsValue(rrs rrSet, i int) (prio, weight uint, value string, err error) {
+	v := rrs.Records[i]
+	var uints []uint
+	switch rrs.Type {
+	default:
+		value = v
+	case "HTTPS", "MX":
+		uints, value, err = splitUints(v, 1)
+		if err != nil {
+			err = fmt.Errorf("desec: parsing %v record value %q: %v", rrs.Type, v, err)
+			return
+		}
+		prio = uints[0]
+	case "SRV", "URI":
+		uints, value, err = splitUints(v, 2)
+		if err != nil {
+			err = fmt.Errorf("desec: parsing %v record value %q: %v", rrs.Type, v, err)
+			return
+		}
+		prio = uints[0]
+		weight = uints[1]
+	}
+	return
+}
+
+func splitUints(s string, n int) ([]uint, string, error) {
+	parts := strings.SplitN(s, " ", n+1)
+	if len(parts) != n+1 {
+		return nil, "", fmt.Errorf("expected %d space separated values, got %d", n+1, len(parts))
+	}
+	uints := make([]uint, n)
+	for i := range uints {
+		v, err := strconv.ParseUint(parts[i], 10, strconv.IntSize)
+		if err != nil {
+			return nil, "", err
+		}
+		uints[i] = uint(v)
+	}
+	return uints, parts[n], nil
+}
+
+// rrSetRecord returns the libdns record value in deSEC conventions.
+//
+// libdns provides priority and weight for DNS entries that support it, the list is
+// documented in the libdns.Record documentation.
+func rrSetRecord(r libdns.Record) string {
+	var v string
+	switch r.Type {
+	default:
+		v = r.Value
+	case "HTTPS", "MX":
+		v = fmt.Sprintf("%d %s", r.Priority, r.Value)
+	case "SRV", "URI":
+		v = fmt.Sprintf("%d %d %s", r.Priority, r.Weight, r.Value)
+	}
+	return v
+}
+
+// libdnsRecords returns the libdns.Records corresponding to a given rrSet.
+func libdnsRecords(rrs rrSet) ([]libdns.Record, error) {
+	records := make([]libdns.Record, 0, len(rrs.Records))
+	name := libdnsName(rrs)
+	ttl := time.Duration(rrs.TTL) * time.Second
+	for i := range rrs.Records {
+		prio, weight, value, err := libdnsValue(rrs, i)
+		if err != nil {
+			return nil, err
+		}
+
+		records = append(records, libdns.Record{
+			Type:     rrs.Type,
+			Name:     name,
+			Value:    value,
+			TTL:      ttl,
+			Priority: prio,
+			Weight:   weight,
+		})
+	}
+	return records, nil
+}
+
+type statusError struct {
+	code   int
+	header http.Header
+	body   []byte
+}
+
+func (err *statusError) Error() string {
+	return fmt.Sprintf("unexpected status code %d: %v", err.code, string(err.body))
+}
+
+var errNotFound = errors.New("not found")
+
+func (p *Provider) httpDo0(ctx context.Context, method, url string, in []byte) ([]byte, error) {
+	var r io.Reader
+	if len(in) > 0 {
+		r = bytes.NewReader(in)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, r)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %v", err)
+	}
+	req.Header.Set("Authorization", "Token "+p.Token)
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+	if len(in) > 0 {
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %v", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %v", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return body, nil
+	default:
+		return nil, &statusError{code: res.StatusCode, header: res.Header, body: body}
+	}
+}
+
+func (p *Provider) httpDo(ctx context.Context, method, url string, in []byte) ([]byte, error) {
+	for {
+		out, err := p.httpDo0(ctx, method, url, in)
+		if s := (*statusError)(nil); errors.As(err, &s) && s.code == http.StatusTooManyRequests {
+			// rate limited, wait until the next request can be send
+			retryAfterHeader := s.header.Get("Retry-After")
+			retryAfter, err := strconv.Atoi(retryAfterHeader)
+			if err != nil {
+				return nil, fmt.Errorf("parsing Retry-After header %q: %v", retryAfterHeader, err)
+			}
+			select {
+			case <-time.After(time.Duration(retryAfter) * time.Second):
+			case <-ctx.Done():
+				return nil, fmt.Errorf("waiting for cooldown to end: %v", ctx.Err())
+			}
+			continue // try again
+		}
+		return out, err
+	}
+}
+
+func (p *Provider) getRRSet(ctx context.Context, zone string, key rrKey) (rrSet, error) {
+	// https://desec.readthedocs.io/en/latest/dns/rrsets.html#retrieving-a-specific-rrset
+	subname := key.Subname
+	if subname == "" {
+		subname = "@"
+	}
+	url := fmt.Sprintf("https://desec.io/api/v1/domains/%s/rrsets/%s/%s", url.PathEscape(zone), url.PathEscape(subname), url.PathEscape(key.Type))
+	outb, err := p.httpDo(ctx, "GET", url, nil)
+	if err != nil {
+		if status, ok := err.(*statusError); ok {
+			if status.code == http.StatusNotFound {
+				return rrSet{}, errNotFound
+			}
+		}
+		return rrSet{}, err
+	}
+
+	var out rrSet
+	if err := json.Unmarshal(outb, &out); err != nil {
+		return rrSet{}, fmt.Errorf("decoding json: %v", err)
+	}
+	return out, nil
+}
+
+func (p *Provider) listRRSets(ctx context.Context, zome string) ([]rrSet, error) {
+	// https://desec.readthedocs.io/en/latest/dns/rrsets.html#retrieving-all-rrsets-in-a-zone
+	url := fmt.Sprintf("https://desec.io/api/v1/domains/%s/rrsets/", url.PathEscape(zome))
+	buf, err := p.httpDo(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []rrSet
+	if err := json.Unmarshal(buf, &out); err != nil {
+		return nil, fmt.Errorf("decoding json: %v", err)
+	}
+	return out, nil
+}
+
+func (p *Provider) putRRSets(ctx context.Context, zone string, rrs []rrSet) error {
+	if len(rrs) == 0 {
+		return nil
+	}
+
+	// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-modification-of-rrsets
+	url := fmt.Sprintf("https://desec.io/api/v1/domains/%s/rrsets/", url.PathEscape(zone))
+
+	var buf []byte
+	var err error
+	buf, err = json.Marshal(rrs)
+	if err != nil {
+		return fmt.Errorf("encoding json: %v", err)
+	}
+
+	_, err = p.httpDo(ctx, "PUT", url, buf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Interface guards
+var (
+	_ libdns.RecordGetter   = (*Provider)(nil)
+	_ libdns.RecordAppender = (*Provider)(nil)
+	_ libdns.RecordSetter   = (*Provider)(nil)
+	_ libdns.RecordDeleter  = (*Provider)(nil)
+)

--- a/desec/provider_test.go
+++ b/desec/provider_test.go
@@ -1,0 +1,548 @@
+// desc_test is an integration test for the desec provider, to run it a deSEC token is required.
+//
+// Run it using
+//
+//	go test . -token=<deSEC token> -domain=<test domain>
+//
+// The <test domain> must not exist prior to running the test. This is mainly to protect against
+// modifications of domains that are in use already.
+package desec_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/libdns/desec"
+	"github.com/libdns/libdns"
+)
+
+var (
+	token  = flag.String("token", "", "deSEC token")
+	domain = flag.String("domain", "", "Domain to test with of the form sld.tld, it must not exist prior to running this test")
+)
+
+var sortRecords = cmpopts.SortSlices(func(x, y libdns.Record) bool {
+	if v := strings.Compare(x.Name, y.Name); v != 0 {
+		return v < 0
+	}
+	if v := strings.Compare(x.Type, y.Type); v != 0 {
+		return v < 0
+	}
+	if v := strings.Compare(x.Value, y.Value); v != 0 {
+		return v < 0
+	}
+	if x.Priority != y.Priority {
+		return x.Priority < y.Priority
+	}
+	if x.Weight != y.Weight {
+		return x.Weight < y.Weight
+	}
+	return false
+})
+
+func httpDo(ctx context.Context, t *testing.T, method, url string, in []byte) ([]byte, int) {
+	t.Helper()
+
+	var r io.Reader
+	if len(in) > 0 {
+		r = bytes.NewReader(in)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Token "+*token)
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+	if len(in) > 0 {
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body, res.StatusCode
+}
+
+func putRRSets(ctx context.Context, t *testing.T, domain, content string) {
+	t.Helper()
+
+	url := fmt.Sprintf("https://desec.io/api/v1/domains/%s/rrsets/", url.PathEscape(domain))
+	body, status := httpDo(ctx, t, "PUT", url, []byte(content))
+	switch status {
+	case http.StatusOK:
+		// success
+	default:
+		t.Fatalf("unexpected status code: %d: %v", status, string(body))
+		panic("never reached")
+	}
+}
+
+func domainExists(ctx context.Context, t *testing.T, domain string) bool {
+	t.Helper()
+
+	url := fmt.Sprintf("https://desec.io/api/v1/domains/%s/", url.PathEscape(domain))
+	body, status := httpDo(ctx, t, "GET", url, nil)
+	switch status {
+	case http.StatusOK:
+		return true
+	case http.StatusNotFound:
+		return false
+	default:
+		t.Fatalf("unexpected status code: %d: %v", status, string(body))
+		panic("never reached")
+	}
+}
+
+func createDomain(ctx context.Context, t *testing.T, domain string) {
+	t.Helper()
+
+	payload, err := json.Marshal(struct {
+		Name string `json:"name"`
+	}{
+		Name: domain,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	url := "https://desec.io/api/v1/domains/"
+	body, status := httpDo(ctx, t, "POST", url, payload)
+	switch status {
+	case http.StatusCreated:
+		// success
+	default:
+		t.Fatalf("unexpected status code: %d: %v", status, string(body))
+		panic("never reached")
+	}
+}
+
+func deleteDomain(ctx context.Context, t *testing.T, domain string) {
+	t.Helper()
+
+	url := fmt.Sprintf("https://desec.io/api/v1/domains/%s/", url.PathEscape(domain))
+	body, status := httpDo(ctx, t, "DELETE", url, nil)
+	switch status {
+	case http.StatusNoContent:
+		// success
+	default:
+		t.Fatalf("unexpected status code: %d: %v", status, string(body))
+		panic("never reached")
+	}
+}
+
+// setup performs all test setup
+//   - skip the test if -domain or -token are not provided
+//   - fail if the domain provided by -domain exists already
+//   - create the domain and setup the deletion of the domain at the end of the test
+//   - ensure that the domain contains only the specified rrsets
+//   - returns a context that can be used in the test
+func setup(t *testing.T, rrsets string) context.Context {
+	t.Helper()
+
+	if *token == "" || *domain == "" {
+		t.Skip("skipping integration test; both -token and -domain must be set")
+	}
+
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+	}
+
+	if domainExists(ctx, t, *domain) {
+		t.Fatalf("domain %q exists, but it must not; either the domain was created outside of this test or something in this test went wrong", *domain)
+	}
+	createDomain(ctx, t, *domain)
+	t.Cleanup(func() { deleteDomain(ctx, t, *domain) })
+
+	// A freshly created domain contains a default NS record. To make sure the domain only has
+	// the rrsets specified in the call to setup we need to delete them first
+	putRRSets(ctx, t, *domain, `[{"subname": "", "type": "NS", "ttl": 3600, "records": []}]`)
+	putRRSets(ctx, t, *domain, rrsets)
+
+	return ctx
+}
+
+func TestGetRecords(t *testing.T) {
+	ctx := setup(t, `[
+		{"subname": "", "type": "NS", "ttl": 3600, "records": []},
+		{"subname": "", "type": "A", "ttl": 3601, "records": ["127.0.0.3"]},
+		{"subname": "www", "type": "A", "ttl": 3600, "records": ["127.0.0.1", "127.0.0.2"]},
+		{"subname": "www", "type": "HTTPS", "ttl": 3600, "records": ["1 . alpn=\"h2\""]},
+		{"subname": "", "type": "MX", "ttl": 3600, "records": ["0 mx0.example.com.", "10 mx1.example.com."]},
+		{"subname": "_sip._tcp", "type": "SRV", "ttl": 3600, "records": ["1 100 5061 sip.example.com."]},
+		{"subname": "_ftp._tcp", "type": "URI", "ttl": 3600, "records": ["1 2 \"ftp://example.com/arst\""]},
+		{"subname": "", "type": "TXT", "ttl": 3600, "records": ["\"hello dns!\""]}
+	]`)
+
+	p := &desec.Provider{
+		Token: *token,
+	}
+
+	want := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.1`,
+			TTL:   3600 * time.Second,
+		},
+		{
+			Type:     "HTTPS",
+			Name:     "www",
+			Value:    `. alpn=h2`,
+			TTL:      3600 * time.Second,
+			Priority: 1,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.2`,
+			TTL:   3600 * time.Second,
+		},
+		{
+			Type:     "MX",
+			Name:     "@",
+			Value:    `mx0.example.com.`,
+			TTL:      3600 * time.Second,
+			Priority: 0,
+		},
+		{
+			Type:     "MX",
+			Name:     "@",
+			Value:    `mx1.example.com.`,
+			TTL:      3600 * time.Second,
+			Priority: 10,
+		},
+		{
+			Type:     "SRV",
+			Name:     "_sip._tcp",
+			Value:    `5061 sip.example.com.`,
+			TTL:      3600 * time.Second,
+			Priority: 1,
+			Weight:   100,
+		},
+		{
+			Type:     "URI",
+			Name:     "_ftp._tcp",
+			Value:    `"ftp://example.com/arst"`,
+			TTL:      3600 * time.Second,
+			Priority: 1,
+			Weight:   2,
+		},
+	}
+
+	got, err := p.GetRecords(ctx, *domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got, sortRecords); diff != "" {
+		t.Fatalf("p.GetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+}
+
+func TestSetRecords(t *testing.T) {
+	ctx := setup(t, `[
+		{"subname": "www", "type": "A", "ttl": 3600, "records": ["127.0.1.1", "127.0.1.2"]},
+		{"subname": "", "type": "TXT", "ttl": 3600, "records": ["\"will be overridden\""]},
+		{"subname": "www", "type": "HTTPS", "ttl": 3600, "records": ["1 . alpn=\"h2\""]},
+		{"subname": "_sip._tcp", "type": "SRV", "ttl": 3600, "records": ["1 100 5061 sip.example.com."]},
+		{"subname": "_ftp._tcp", "type": "URI", "ttl": 3600, "records": ["1 2 \"ftp://example.com/arst\""]},
+		{"subname": "", "type": "MX", "ttl": 3600, "records": ["0 mx0.example.com.", "10 mx1.example.com."]}
+	]`)
+
+	p := &desec.Provider{
+		Token: *token,
+	}
+
+	records := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.1`,
+			TTL:   3600 * time.Second,
+		},
+		{
+			Type:     "HTTPS",
+			Name:     "www",
+			Value:    `. alpn=h2`,
+			TTL:      3600 * time.Second,
+			Priority: 1,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.2`,
+			TTL:   3600 * time.Second,
+		},
+		{
+			Type:     "MX",
+			Name:     "@",
+			Value:    `mx0.example.com.`,
+			TTL:      3600 * time.Second,
+			Priority: 0,
+		},
+		{
+			Type:     "MX",
+			Name:     "@",
+			Value:    `mx1.example.com.`,
+			TTL:      3600 * time.Second,
+			Priority: 10,
+		},
+		{
+			Type:     "SRV",
+			Name:     "_sip._tcp",
+			Value:    `5061 sip.example.com.`,
+			TTL:      3600 * time.Second,
+			Priority: 1,
+			Weight:   100,
+		},
+		{
+			Type:     "URI",
+			Name:     "_ftp._tcp",
+			Value:    `"ftp://example.com/arst"`,
+			TTL:      3600 * time.Second,
+			Priority: 1,
+			Weight:   2,
+		},
+	}
+
+	created, err := p.SetRecords(ctx, *domain, records)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The records that already existed are not returned by SetRecords.
+	wantCreated := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.1`,
+			TTL:   3600 * time.Second,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.2`,
+			TTL:   3600 * time.Second,
+		},
+	}
+	if diff := cmp.Diff(wantCreated, created, sortRecords); diff != "" {
+		t.Fatalf("p.SetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+
+	got, err := p.GetRecords(ctx, *domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(records, got, sortRecords); diff != "" {
+		t.Fatalf("p.GetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+}
+
+func TestAppendRecords(t *testing.T) {
+	ctx := setup(t, `[
+		{"subname": "www", "type": "A", "ttl": 3600, "records": ["127.0.0.1"]},
+		{"subname": "", "type": "TXT", "ttl": 3600, "records": ["\"hello dns!\""]}
+	]`)
+
+	p := &desec.Provider{
+		Token: *token,
+	}
+
+	append := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.2`,
+			TTL:   3600 * time.Second,
+		},
+	}
+
+	added, err := p.AppendRecords(ctx, *domain, append)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantAdded := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.2`,
+			TTL:   3600 * time.Second,
+		},
+	}
+	if diff := cmp.Diff(added, wantAdded, sortRecords); diff != "" {
+		t.Fatalf("p.SetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+
+	got, err := p.GetRecords(ctx, *domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.1`,
+			TTL:   3600 * time.Second,
+		},
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.2`,
+			TTL:   3600 * time.Second,
+		},
+	}
+	if diff := cmp.Diff(want, got, sortRecords); diff != "" {
+		t.Fatalf("p.GetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+}
+
+func TestDeleteRecords(t *testing.T) {
+	ctx := setup(t, `[
+		{"subname": "www", "type": "A", "ttl": 3600, "records": ["127.0.0.1"]},
+		{"subname": "", "type": "TXT", "ttl": 3600, "records": ["\"hello dns!\""]}
+	]`)
+
+	p := &desec.Provider{
+		Token: *token,
+	}
+
+	delete := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "@",
+			Value: `127.0.0.3`,
+			TTL:   time.Second * 3601,
+		},
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+	}
+
+	deleted, err := p.DeleteRecords(ctx, *domain, delete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantDeleted := []libdns.Record{
+		{
+			Type:  "TXT",
+			Name:  "@",
+			Value: `"hello dns!"`,
+			TTL:   time.Second * 3600,
+		},
+	}
+	if diff := cmp.Diff(deleted, wantDeleted, sortRecords); diff != "" {
+		t.Fatalf("p.SetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+
+	got, err := p.GetRecords(ctx, *domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []libdns.Record{
+		{
+			Type:  "A",
+			Name:  "www",
+			Value: `127.0.0.1`,
+			TTL:   3600 * time.Second,
+		},
+	}
+	if diff := cmp.Diff(want, got, sortRecords); diff != "" {
+		t.Fatalf("p.GetRecords() unexpected diff [-want +got]: %s", diff)
+	}
+}


### PR DESCRIPTION
This PR adds an implementation for the deSEC provider, the main thing that's missing is to write a readme file and to figure out if there are ways to reuse code in the `Provider` method implementations (I did not have any luck finding one without sacrificing readability).

Fixes #43 