### PR TITLE
Add do.de provider

### DIFF
--- a/dode/LICENSE
+++ b/dode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) d-k-bo 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dode/README.md
+++ b/dode/README.md
@@ -1,0 +1,12 @@
+[do.de][dode] for [`libdns`](https://github.com/libdns/libdns)
+=======================
+
+[![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/dode)
+
+This package implements the [libdns interfaces](https://github.com/libdns/libdns) for [do.de][dode], allowing you to manage DNS records.
+
+The [do.de][dode] API only supports creating and removing TXT records for domains starting with `_acme-challenge.`. This means that this package can only be used when issuing a TLS certificate using the [DNS-01 Challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
+
+To authenticate with the [do.de][dode] API, you need an API token. You can retrieve by logging into your [do.de][dode] account and navigating to `Domains > Einstellungen >  Let's Encrypt API-Token`.
+
+[dode]: https://do.de

--- a/dode/client.go
+++ b/dode/client.go
@@ -1,0 +1,95 @@
+// Direct implementation of all required do.de DNS API endpoints
+
+package dode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const baseURl = "https://www.do.de/api"
+
+type ApiResponse struct {
+	Domain  *string `json:"domain"`
+	Success *bool   `json:"success"`
+	Error   *string `json:"error"`
+}
+
+func (p *Provider) createACMERecord(ctx context.Context, domain string, value string) error {
+	baseURL, _ := url.Parse(baseURl)
+	endpoint := baseURL.JoinPath("letsencrypt")
+
+	query := endpoint.Query()
+	query.Set("token", p.APIToken)
+	query.Set("domain", domain)
+	query.Set("value", value)
+
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	var apiResponse ApiResponse
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&apiResponse)
+	if err != nil {
+		return err
+	}
+
+	if apiResponse.Error != nil {
+		return fmt.Errorf(*apiResponse.Error)
+	}
+	if apiResponse.Success == nil || !*apiResponse.Success {
+		return fmt.Errorf("creating the ACME record was not successfull")
+	}
+
+	return nil
+}
+
+func (p *Provider) deleteACMERecord(ctx context.Context, domain string) error {
+	baseURL, _ := url.Parse(baseURl)
+	endpoint := baseURL.JoinPath("letsencrypt")
+
+	query := endpoint.Query()
+	query.Set("token", p.APIToken)
+	query.Set("domain", domain)
+	query.Set("action", "delete")
+
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	var apiResponse ApiResponse
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&apiResponse)
+	if err != nil {
+		return err
+	}
+
+	if apiResponse.Error != nil {
+		return fmt.Errorf(*apiResponse.Error)
+	}
+	if apiResponse.Success == nil || !*apiResponse.Success {
+		return fmt.Errorf("creating the ACME record was not successfull")
+	}
+
+	return nil
+}

--- a/dode/go.mod
+++ b/dode/go.mod
@@ -1,0 +1,5 @@
+module github.com/libdns/dode
+
+go 1.18
+
+require github.com/libdns/libdns v0.2.2

--- a/dode/go.sum
+++ b/dode/go.sum
@@ -1,0 +1,2 @@
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/dode/provider.go
+++ b/dode/provider.go
@@ -1,0 +1,82 @@
+// Package dode implements a DNS record management client compatible
+// with the libdns interfaces for do.de. Unfortunately, the do.de API only
+// supports creating and removing TXT records for domains starting with `_acme-challenge.`
+package dode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/libdns/libdns"
+)
+
+// Provider facilitates DNS record manipulation with do.de.
+type Provider struct {
+	// API token for do.de API
+	APIToken string `json:"api_token,omitempty"`
+}
+
+const notSupportedErrorMsg = "the do.de API only supports creating and removing TXT records for domains starting with '_acme-challenge.'"
+const acmeChallenge = "_acme-challenge."
+
+// GetRecords lists all the records in the zone.
+//
+// This is unsupported by the do.de API.
+func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
+	return nil, fmt.Errorf(notSupportedErrorMsg)
+}
+
+// AppendRecords adds records to the zone. It returns the records that were added.
+//
+// The do.de API only supports creating TXT records that start with `_acme-challenge.`.
+func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	for _, rec := range records {
+		if rec.Type != "TXT" || !strings.HasPrefix(rec.Name, acmeChallenge) {
+			return nil, fmt.Errorf(notSupportedErrorMsg)
+		}
+
+		name := libdns.AbsoluteName(rec.Name, zone)
+		err := p.createACMERecord(ctx, strings.TrimSuffix(name, "."), rec.Value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return records, nil
+
+}
+
+// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
+// It returns the updated records.
+//
+// The do.de API only supports creating TXT records that start with `_acme-challenge.`.
+func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	return p.AppendRecords(ctx, zone, records)
+}
+
+// DeleteRecords deletes the records from the zone. It returns the records that were deleted.
+//
+// The do.de API only supports deleting TXT records that start with `_acme-challenge.`.
+func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	for _, rec := range records {
+		if rec.Type != "TXT" || !strings.HasPrefix(rec.Name, acmeChallenge) {
+			return nil, fmt.Errorf(notSupportedErrorMsg)
+		}
+
+		err := p.deleteACMERecord(ctx, strings.TrimSuffix(libdns.AbsoluteName(rec.Name, zone), "."))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return records, nil
+}
+
+// Interface guards
+var (
+	_ libdns.RecordGetter   = (*Provider)(nil)
+	_ libdns.RecordAppender = (*Provider)(nil)
+	_ libdns.RecordSetter   = (*Provider)(nil)
+	_ libdns.RecordDeleter  = (*Provider)(nil)
+)

--- a/dode/provider_test.go
+++ b/dode/provider_test.go
@@ -1,0 +1,49 @@
+// Integration tests for the do.de provider
+
+package dode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/libdns/libdns"
+)
+
+var (
+	apiToken    = ""
+	zone        = ""
+	testRecords = []libdns.Record{
+		{
+			Type:  "TXT",
+			Name:  "_acme-challenge.test",
+			Value: "foo",
+		},
+	}
+)
+
+func TestMain(m *testing.M) {
+	fmt.Println("Loading environment variables to set up provider")
+	apiToken = os.Getenv("LIBDNS_DODE_API_TOKEN")
+	zone = os.Getenv("LIBDNS_DODE_ZONE")
+
+	os.Exit(m.Run())
+}
+
+func TestProvider_AppendDeleteRecords(t *testing.T) {
+	p := &Provider{
+		APIToken: apiToken,
+	}
+
+	_, err := p.AppendRecords(context.TODO(), zone, testRecords)
+	if err != nil {
+		t.Fatalf("appending record failed: %v", err)
+		return
+	}
+
+	_, err = p.DeleteRecords(context.TODO(), zone, testRecords)
+	if err != nil {
+		t.Fatalf("deleting record failed: %v", err)
+	}
+}


### PR DESCRIPTION
This is a partial implementation of the libdns interfaces for [do.de](https://do.de). Since the do.de API only supports creating TXT records for ACME, an error is returned in any other situation.

This is my first time using Go, so don't be afraid to point out any style issues, errors, bad practices etc.

Closes #122 