### PR TITLE
Don't use `.@` for relative names in [SRV|ServiceBinding].RR()

### DIFF
--- a/record_test.go
+++ b/record_test.go
@@ -477,3 +477,64 @@ func TestSvcParamsString(t *testing.T) {
 		}
 	}
 }
+
+func TestRelativeRRNames(t *testing.T) {
+	for _, test := range []struct {
+		input  Record
+		expect string
+	}{
+		{
+			input: ServiceBinding{
+				Name:          "@",
+				Scheme:        "examplescheme",
+				URLSchemePort: 1234,
+				TTL:           1 * time.Hour,
+				Priority:      1,
+				Target:        ".",
+				Params:        SvcParams{},
+			},
+			expect: "_1234._examplescheme",
+		},
+		{
+			input: SRV{
+				Name:      "@",
+				Service:   "exampleservice",
+				Transport: "tcp",
+				TTL:       1 * time.Hour,
+				Priority:  1,
+				Weight:    2,
+				Target:    ".",
+			},
+			expect: "_exampleservice._tcp",
+		},
+		{
+			input: ServiceBinding{
+				Name:          "test",
+				Scheme:        "examplescheme",
+				URLSchemePort: 1234,
+				TTL:           1 * time.Hour,
+				Priority:      1,
+				Target:        ".",
+				Params:        SvcParams{},
+			},
+			expect: "_1234._examplescheme.test",
+		},
+		{
+			input: SRV{
+				Name:      "test",
+				Service:   "exampleservice",
+				Transport: "tcp",
+				TTL:       1 * time.Hour,
+				Priority:  1,
+				Weight:    2,
+				Target:    ".",
+			},
+			expect: "_exampleservice._tcp.test",
+		},
+	} {
+		rr := test.input.RR()
+		if rr.Name != test.expect {
+			t.Errorf("Expected %q, got %q", test.expect, rr.Name)
+		}
+	}
+}

--- a/rrtypes.go
+++ b/rrtypes.go
@@ -3,6 +3,7 @@ package libdns
 import (
 	"fmt"
 	"net/netip"
+	"strings"
 	"time"
 )
 
@@ -163,6 +164,8 @@ func (s SRV) RR() RR {
 		// Otherwise, we need to prepend the underscores to the name.
 		name = fmt.Sprintf("_%s._%s.%s", s.Service, s.Transport, s.Name)
 	}
+
+	name = strings.TrimSuffix(name, ".@")
 
 	return RR{
 		Name: name,
@@ -327,6 +330,8 @@ func (s ServiceBinding) RR() RR {
 	} else {
 		params = s.Params.String()
 	}
+
+	name = strings.TrimSuffix(name, ".@")
 
 	return RR{
 		Name: name,


### PR DESCRIPTION
While replying to #161, I noticed that `.RR()` gives odd results for `SRV` and `ServiceBinding` records at the zone apex:

```go
package main

import (
	"fmt"
	"time"

	"github.com/libdns/libdns"
)

func main() {
	records := []libdns.Record{
		libdns.ServiceBinding{
			Name:          "@",
			Scheme:        "examplescheme",
			URLSchemePort: 1234,
			TTL:           1 * time.Hour,
			Priority:      1,
			Target:        ".",
			Params:        libdns.SvcParams{},
		},
		libdns.SRV{
			Name:      "@",
			Service:   "exampleservice",
			Transport: "tcp",
			TTL:       1 * time.Hour,
			Priority:  1,
			Weight:    2,
			Target:    ".",
		},
	}

	rrs := make([]libdns.RR, len(records))
	for i, record := range records {
		rrs[i] = record.RR()
	}

	for _, rr := range rrs {
		fmt.Println(rr.Name)
	}
}
```
```log
_1234._examplescheme.@
_exampleservice._tcp.@
```

`libdns` has no problem parsing names like `_1234._examplescheme.@`, but users would typically expect `_1234._examplescheme` instead, so I've updated the code to trim any `.@` suffixes.