### PR TITLE
Make all zero values have `.RR().Data == ""`

### DIFF
--- a/record_test.go
+++ b/record_test.go
@@ -622,3 +622,40 @@ func TestRelativeRRNames(t *testing.T) {
 		}
 	}
 }
+
+func TestRRDataZeroValues(t *testing.T) {
+	for _, test := range []Record{
+		Address{
+			Name: "example.com",
+		},
+		CAA{
+			Name: "example.com",
+		},
+		CNAME{
+			Name: "example.com",
+		},
+		MX{
+			Name: "example.com",
+		},
+		NS{
+			Name: "example.com",
+		},
+		SRV{
+			Name:      "example.com",
+			Transport: "tcp",
+			Service:   "exampleservice",
+		},
+		ServiceBinding{
+			Name:   "example.com",
+			Scheme: "https",
+		},
+		TXT{
+			Name: "example.com",
+		},
+	} {
+		rr := test.RR()
+		if rr.Data != "" {
+			t.Errorf("%s: Expected empty Data, got '%s'", rr.Type, rr.Data)
+		}
+	}
+}

--- a/rrtypes.go
+++ b/rrtypes.go
@@ -28,11 +28,19 @@ func (a Address) RR() RR {
 	if a.IP.Is6() {
 		recType = "AAAA"
 	}
+	data := a.IP.String()
+	if a.IP == (netip.Addr{}) {
+		// If the IP address is null, then we get the string "invalid IP". We'll
+		// convert this to the empty string to make
+		// [libdns.RecordDeleter.DeleteRecords] easier to use when missing IP
+		// addresses are passed.
+		data = ""
+	}
 	return RR{
 		Name: a.Name,
 		TTL:  a.TTL,
 		Type: recType,
-		Data: a.IP.String(),
+		Data: data,
 	}
 }
 
@@ -50,11 +58,16 @@ type CAA struct {
 }
 
 func (c CAA) RR() RR {
+	data := fmt.Sprintf(`%d %s %q`, c.Flags, c.Tag, c.Value)
+	// Make sure that the zero value is an empty string
+	if c.Flags == 0 && c.Tag == "" && c.Value == "" {
+		data = ""
+	}
 	return RR{
 		Name: c.Name,
 		TTL:  c.TTL,
 		Type: "CAA",
-		Data: fmt.Sprintf(`%d %s %q`, c.Flags, c.Tag, c.Value),
+		Data: data,
 	}
 }
 
@@ -85,11 +98,16 @@ type MX struct {
 }
 
 func (m MX) RR() RR {
+	data := fmt.Sprintf("%d %s", m.Preference, m.Target)
+	// Make sure that the zero value is an empty string
+	if m.Preference == 0 && m.Target == "" {
+		data = ""
+	}
 	return RR{
 		Name: m.Name,
 		TTL:  m.TTL,
 		Type: "MX",
-		Data: fmt.Sprintf("%d %s", m.Preference, m.Target),
+		Data: data,
 	}
 }
 
@@ -167,11 +185,17 @@ func (s SRV) RR() RR {
 
 	name = strings.TrimSuffix(name, ".@")
 
+	data := fmt.Sprintf("%d %d %d %s", s.Priority, s.Weight, s.Port, s.Target)
+	// Make sure that the zero value is an empty string
+	if s.Priority == 0 && s.Weight == 0 && s.Port == 0 && s.Target == "" {
+		data = ""
+	}
+
 	return RR{
 		Name: name,
 		TTL:  s.TTL,
 		Type: "SRV",
-		Data: fmt.Sprintf("%d %d %d %s", s.Priority, s.Weight, s.Port, s.Target),
+		Data: data,
 	}
 }
 
@@ -333,11 +357,17 @@ func (s ServiceBinding) RR() RR {
 
 	name = strings.TrimSuffix(name, ".@")
 
+	data := fmt.Sprintf("%d %s %s", s.Priority, s.Target, params)
+	// Make sure that the zero value is an empty string
+	if s.Priority == 0 && s.Target == "" && params == "" {
+		data = ""
+	}
+
 	return RR{
 		Name: name,
 		TTL:  s.TTL,
 		Type: recType,
-		Data: fmt.Sprintf("%d %s %s", s.Priority, s.Target, params),
+		Data: data,
 	}
 }
 


### PR DESCRIPTION
(Noticed in https://github.com/libdns/rfc2136/pull/9#discussion_r2051132593)

The `Address.IP` field is allowed to be zero-initialized for use in `DeleteRecords`:

https://github.com/libdns/libdns/blob/5ab1d4de259f1eb914085c61784ad9176ea8e803/libdns.go#L200-L205

Currently, calling `.RR()` on such an `Address` gives `rr.Data == "invalid IP"`, but this is a fairly surprising zero value, so this PR changes this to use the more conventional `""`.