### PR TITLE
Create RR.ProviderData (close #119)

### DIFF
--- a/libdns.go
+++ b/libdns.go
@@ -19,6 +19,15 @@
 // Specific record types such as [Address], [SRV], [TXT], and others implement
 // the [Record] interface.
 //
+// Record values should not be primitvely compared (==) unless it is [RR],
+// because some struct types contain maps, for which equality is not defined;
+// additionally, some packages may attach custom data to each RR struct-type's
+// `ProviderData` field, which values might not be comparable either. The
+// `ProviderData` fields are not portable across providers, or possibly even
+// zones. Because it is not portable, and we want to ensure that [RR] structs
+// remain both portable and comparable, the `RR()` methods do not preserve
+// `ProviderData` in their return values.
+//
 // Implementations of the libdns interfaces should accept as input any [Record]
 // value, and should return as output the concrete struct types that implement
 // the [Record] interface (i.e. [Address], [TXT], [ServiceBinding], etc). This

--- a/libdns.go
+++ b/libdns.go
@@ -22,7 +22,7 @@
 // Record values should not be primitvely compared (==) unless it is [RR],
 // because some struct types contain maps, for which equality is not defined;
 // additionally, some packages may attach custom data to each RR struct-type's
-// `ProviderData` field, which values might not be comparable either. The
+// `ProviderData` field, whose values might not be comparable either. The
 // `ProviderData` fields are not portable across providers, or possibly even
 // zones. Because it is not portable, and we want to ensure that [RR] structs
 // remain both portable and comparable, the `RR()` methods do not preserve

--- a/record.go
+++ b/record.go
@@ -103,13 +103,6 @@ type RR struct {
 	// Implementations are not expected to support RFC 3597 “\#” escape
 	// sequences, but may choose to do so if they wish.
 	Data string `json:"data"`
-
-	// Optional data associated with the provider serving this RR.
-	// This could be the data structure the provider's API returns
-	// to represent this RR, for example. The data in this field
-	// is not cross-provider compatible and has no defined semantics.
-	// Each provider package should document if they use this field.
-	ProviderData any `json:"provider_data,omitempty"`
 }
 
 // RR returns itself. This may be the case when trying to parse an RR type

--- a/record.go
+++ b/record.go
@@ -57,7 +57,7 @@ type RR struct {
 	//
 	// Valid, but probably doesn't do what you want:
 	//   - “www.example.net” (refers to “www.example.net.example.com.”)
-	Name string
+	Name string `json:"name"`
 
 	// The time-to-live of the record. This is represented in the DNS zone file as
 	// an unsigned integral number of seconds, but is provided here as a
@@ -69,7 +69,7 @@ type RR struct {
 	// Note that some providers may reject or silently increase TTLs that are below
 	// a certain threshold, and that DNS resolvers may choose to ignore your TTL
 	// settings, so it is recommended to not rely on the exact TTL value.
-	TTL time.Duration
+	TTL time.Duration `json:"ttl"`
 
 	// The type of the record as an uppercase string. DNS provider packages are
 	// encouraged to support as many of the most common record types as possible,
@@ -77,7 +77,7 @@ type RR struct {
 	//
 	// Other custom record types may be supported with implementation-defined
 	// behavior.
-	Type string
+	Type string `json:"type"`
 
 	// The data (or "value") of the record. This field should be formatted in
 	// the *unescaped* standard zone file syntax (technically, the "RDATA" field
@@ -102,7 +102,14 @@ type RR struct {
 	//
 	// Implementations are not expected to support RFC 3597 “\#” escape
 	// sequences, but may choose to do so if they wish.
-	Data string
+	Data string `json:"data"`
+
+	// Optional data associated with the provider serving this RR.
+	// This could be the data structure the provider's API returns
+	// to represent this RR, for example. The data in this field
+	// is not cross-provider compatible and has no defined semantics.
+	// Each provider package should document if they use this field.
+	ProviderData any `json:"provider_data"`
 }
 
 // RR returns itself. This may be the case when trying to parse an RR type

--- a/record.go
+++ b/record.go
@@ -109,7 +109,7 @@ type RR struct {
 	// to represent this RR, for example. The data in this field
 	// is not cross-provider compatible and has no defined semantics.
 	// Each provider package should document if they use this field.
-	ProviderData any `json:"provider_data"`
+	ProviderData any `json:"provider_data,omitempty"`
 }
 
 // RR returns itself. This may be the case when trying to parse an RR type

--- a/rrtypes.go
+++ b/rrtypes.go
@@ -21,6 +21,10 @@ type Address struct {
 	Name string
 	TTL  time.Duration
 	IP   netip.Addr
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (a Address) RR() RR {
@@ -55,6 +59,10 @@ type CAA struct {
 	Flags uint8 // As of March 2025, the only valid values are 0 and 128.
 	Tag   string
 	Value string
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (c CAA) RR() RR {
@@ -77,6 +85,10 @@ type CNAME struct {
 	Name   string
 	TTL    time.Duration
 	Target string
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (c CNAME) RR() RR {
@@ -95,6 +107,10 @@ type MX struct {
 	TTL        time.Duration
 	Preference uint16 // Lower values indicate that clients should prefer this server. This field is similar to the “Priority” field in SRV records.
 	Target     string // The hostname of the mail server
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (m MX) RR() RR {
@@ -127,6 +143,10 @@ type NS struct {
 	Name   string
 	TTL    time.Duration
 	Target string
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (n NS) RR() RR {
@@ -169,6 +189,10 @@ type SRV struct {
 	Weight   uint16 // Higher values indicate that clients should prefer this server when choosing between targets with the same priority
 	Port     uint16 // The port on which the service is running.
 	Target   string // The hostname of the server providing the service, which must not point to a CNAME.
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (s SRV) RR() RR {
@@ -322,6 +346,10 @@ type ServiceBinding struct {
 	// ignore the entire record. This is similar to the “critical” flag in CAA
 	// records.
 	Params SvcParams
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 // RR converts the parsed record data to a generic [Record] struct.
@@ -398,6 +426,10 @@ type TXT struct {
 	// [RFC 7208 §3.3]: https://datatracker.ietf.org/doc/html/rfc7208#section-3.3
 	// [DNSControl explainer]: https://docs.dnscontrol.org/developer-info/opinions#opinion-8-txt-records-are-one-long-string
 	Text string
+
+	// Optional custom data associated with the provider serving this record.
+	// See the package godoc for important details on this field.
+	ProviderData any
 }
 
 func (t TXT) RR() RR {


### PR DESCRIPTION
This is my proposal for being able to attach provider-specific (meta?)data to an RR. See #119.

However, since provider implementations are supposed to return the concrete struct types, not RRs, we'll likely need to add this field to all the specific structs (Address, TXT, CNAME, etc...).

I also added JSON tags to the RR struct, in preparation for 1.0, since JSON-serialization seems like it could be a common pattern. (Caddy/CertMagic do not do this, but I could see having separate JSON identifiers being handy.)

Finally, I am torn between `Meta`, `Metadata`, and `ProviderData` for the field name. Any thoughts?

@gucci-on-fleek What do you think?