### PR TITLE
Introduce AtomicErr (close #175)

### DIFF
--- a/libdns.go
+++ b/libdns.go
@@ -148,15 +148,6 @@ type RecordSetter interface {
 	// consistent state. Implementations should document their atomicity
 	// guarantees (or lack thereof).
 	//
-	// Calls to SetRecords are presumed to be atomic; that is, if err == nil,
-	// then all of the requested changes were made; if err != nil, then none of
-	// the requested changes were made, and the zone is as if the method was
-	// never called. Some provider APIs may not support atomic operations, so it
-	// is recommended that implementations synthesize atomicity by transparently
-	// rolling back changes on failure; if this is not possible, then it should
-	// be clearly documented that errors may result in partial changes to the
-	// zone.
-	//
 	// If SetRecords is used to add a CNAME record to a name with other existing
 	// non-DNSSEC records, implementations may either fail with an error, add
 	// the CNAME and leave the other records in place (in violation of the DNS

--- a/libdns.go
+++ b/libdns.go
@@ -140,12 +140,11 @@ type RecordSetter interface {
 	// err == nil, then all of the requested changes were made, and if err != nil,
 	// then the zone remains as if the method was never called. However, as very
 	// few providers offer batch/atomic operations, the actual result of a call
-	// where err != nil is undefined. If it's possible for implementations to
-	// synthesize atomicity by transparently rolling back changes on failure,
-	// this may not always succeed, but may be attempted to try to restore zone
-	// consistency. For calls that error atomically, implementations should return
-	// AtomicErr as the error so callers may know that their zone remains in a
-	// consistent state. Implementations should document their atomicity
+	// where err != nil is undefined. Implementations may implement synthetic
+	// atomicity that rolls back partial changes on failure ONLY if it can be
+	// done reliably. For calls that error atomically, implementations should
+	// return [AtomicErr] as the error so callers may know that their zone remains
+	// in a consistent state. Implementations should document their atomicity
 	// guarantees (or lack thereof).
 	//
 	// If SetRecords is used to add a CNAME record to a name with other existing


### PR DESCRIPTION
This introduces AtomicErr, and clarifies the documentation regarding atomicity. It is no longer expected/required for SetRecords, but encouraged, and AtomicErr can be returned to inform callers of the state of their zone.