### PR TITLE
Clarify `SetRecords` behaviour

### DIFF
--- a/libdns.go
+++ b/libdns.go
@@ -129,6 +129,25 @@ type RecordSetter interface {
 	// zone so that for each RRset in the input, the records provided in the input
 	// are the only members of their RRset in the output zone.
 	//
+	// SetRecords is distinct from [libdns.RecordAppender.AppendRecords] in that
+	// AppendRecords *only* adds records to the zone, while SetRecords may also
+	// delete records if necessary. Therefore, SetRecords behaves similarly to
+	// the following code:
+	//
+	//	func SetRecords(ctx context.Context, zone string, recs []Record) ([]Record, error) {
+	//		prevs, _ := p.GetRecords(ctx, zone)
+	//		toDelete := []Record{}
+	//		for _, prev := range prevs {
+	//			for _, new := range recs {
+	//				if prev.RR().Name == new.RR().Name && prev.RR().Type == new.RR().Type {
+	//					toDelete = append(toDelete, prev)
+	//				}
+	//			}
+	//		}
+	//		DeleteRecords(ctx, zone, toDelete)
+	//		return AppendRecords(ctx, zone, recs)
+	//	}
+	//
 	// Implementations may decide whether or not to support DNSSEC-related records
 	// in calls to SetRecords, but should document their decision. Note that the
 	// decision to support DNSSEC records in SetRecords is independent of the


### PR DESCRIPTION
Some implementations implement `SetRecords` and `AppendRecords` identically, but this is incorrect. This commit updates the `SetRecords` documentation to clarify that `SetRecords` can only be implemented by a combination of `DeleteRecords` and `AppendRecords`, not `AppendRecords` alone.

Fixes #186.