### PR TITLE
Add basic end-to-end tests and in-memory DNS provider for libdns

### DIFF
--- a/libdnstest/example/example_test.go
+++ b/libdnstest/example/example_test.go
@@ -1,23 +1,23 @@
-package dummy_test
+package example_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/libdns/libdns"
-	"github.com/libdns/libdns/e2e"
-	"github.com/libdns/libdns/e2e/dummy"
+	"github.com/libdns/libdns/libdnstest"
+	"github.com/libdns/libdns/libdnstest/example"
 )
 
-func TestDummyProvider(t *testing.T) {
-	provider := dummy.New("example.com.")
-	testSuite := e2e.NewTestSuite(provider, "example.com.")
+func TestExampleProvider(t *testing.T) {
+	provider := example.New("example.com.")
+	testSuite := libdnstest.NewTestSuite(provider, "example.com.")
 	testSuite.RunTests(t)
 }
 
-func TestDummyProviderWithSkippedRecords(t *testing.T) {
-	provider := dummy.New("example.com.")
-	testSuite := e2e.NewTestSuite(provider, "example.com.")
+func TestExampleProviderWithSkippedRecords(t *testing.T) {
+	provider := example.New("example.com.")
+	testSuite := libdnstest.NewTestSuite(provider, "example.com.")
 
 	// Example: skip some types that some provider may not implement
 	testSuite.SkipRRTypes = map[string]bool{
@@ -34,15 +34,15 @@ func TestDummyProviderWithSkippedRecords(t *testing.T) {
 }
 
 type noZoneListerProvider struct {
-	provider *dummy.Provider
+	provider *example.Provider
 }
 
-func TestDummyProviderNoZoneLister(t *testing.T) {
-	// let's pretent we have provider that does not implement ZoneListener
-	provider := &noZoneListerProvider{provider: dummy.New("example.com.")}
+func TestExampleProviderNoZoneLister(t *testing.T) {
+	// let's pretend we have provider that does not implement ZoneLister
+	provider := &noZoneListerProvider{provider: example.New("example.com.")}
 
-	// this how how we test it:
-	suite := e2e.NewTestSuite(e2e.WrapNoZoneLister(provider), "example.com.")
+	// this is how we test it:
+	suite := libdnstest.NewTestSuite(libdnstest.WrapNoZoneLister(provider), "example.com.")
 	suite.RunTests(t)
 }
 

--- a/libdnstest/example/provider.go
+++ b/libdnstest/example/provider.go
@@ -1,5 +1,5 @@
-// Package dummy provides an in-memory implementation of all libdns interfaces for testing.
-package dummy
+// Package example provides an in-memory implementation of all libdns interfaces for testing.
+package example
 
 import (
 	"context"

--- a/libdnstest/libdnstest.go
+++ b/libdnstest/libdnstest.go
@@ -1,17 +1,17 @@
-// Package e2e provides end-to-end testing utilities for libdns provider implementations.
+// Package libdnstest provides testing utilities for libdns provider implementations.
 //
 // These tests create, modify, and delete DNS records with names like "test-append",
 // "test-set", "test-delete", and "test-lifecycle" to validate provider behavior.
 //
 // For real DNS provider implementations, use dedicated test zones since the tests
-// will modify DNS records. The dummy provider uses in-memory storage and is completely safe.
+// will modify DNS records. The example provider uses in-memory storage and is completely safe.
 //
 // Tests run sequentially (not in parallel) to avoid conflicts when testing real
 // DNS providers that interact with external services.
 //
 // # Usage
 //
-//	suite := e2e.NewTestSuite(yourProvider, "example.com.")
+//	suite := libdnstest.NewTestSuite(yourProvider, "example.com.")
 //	suite.RunTests(t)
 //
 // # Provider Without ZoneLister
@@ -19,8 +19,8 @@
 // If your provider doesn't implement ZoneLister, use WrapNoZoneLister:
 //
 //	provider := YourProvider{...}
-//	wrappedProvider := e2e.WrapNoZoneLister(provider)
-//	suite := e2e.NewTestSuite(wrappedProvider, "example.com.")
+//	wrappedProvider := libdnstest.WrapNoZoneLister(provider)
+//	suite := libdnstest.NewTestSuite(wrappedProvider, "example.com.")
 //	suite.RunTests(t)
 //
 // # Custom Record Construction
@@ -30,7 +30,7 @@
 // The TestSuite.AppendRecordFunc field allows you to provide a custom function
 // to create Record instances for AppendRecords tests:
 //
-//	suite := e2e.NewTestSuite(yourProvider, "example.com.")
+//	suite := libdnstest.NewTestSuite(yourProvider, "example.com.")
 //	suite.AppendRecordFunc = func(record libdns.Record) libdns.Record {
 //		// Return your provider's specific Record implementation
 //		return yourProvider.NewRecord(record.RR())
@@ -38,7 +38,7 @@
 //
 // For Set and Delete operations, the tests automatically retrieve existing records
 // from the provider to ensure compatibility with provider-specific Record implementations.
-package e2e
+package libdnstest
 
 import (
 	"context"


### PR DESCRIPTION
I came across libdns while checking an outdated Caddy DNS provider module that depends on it.

I noticed there were no functional tests defined - only a recommendation to test. Because of that, many providers have issues.

To help, I added a small set of end-to-end tests and a simple in-memory (non-synchronized) DNS provider. It is a basic implementation that passes the tests, to test the tests. 

I also implemented these tests on my Cloudflare libdns provider fork:  
https://github.com/libdns/cloudflare/compare/master...AndrianBdn:cloudflare:master 

It turns out the Cloudflare DNS provider has some weird behavior due to unusual FQDN normalization in CNAME (this is actually very common problem - might we worth documenting if libdns clients expect dots in external CNAMEs or not). 

I've tried to test DigitalOcean implementation, however it quickly become evident that its current SetRecords implementation is just a hack: https://github.com/libdns/digitalocean/blob/master/provider.go#L64

I think the libdns community would benefit from having these basic e2e tests. The tests could also live in the template repo, but having a basic reference in-memory provider and test suite in the main library would likely be more useful.

I would open PRs with e2e tests and fixes to cloudflare, route53, maybe to digitalocean too once the framework is established. 