### PR TITLE
Fix cleanup of SRV and SVCB records in libdnstest

### DIFF
--- a/libdnstest/example/example_test.go
+++ b/libdnstest/example/example_test.go
@@ -61,3 +61,12 @@ func (w *noZoneListerProvider) SetRecords(ctx context.Context, zone string, reco
 func (w *noZoneListerProvider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	return w.provider.DeleteRecords(ctx, zone, records)
 }
+
+func TestExampleProviderStrict(t *testing.T) {
+	provider := example.New("example.com.")
+	testSuite := libdnstest.NewTestSuite(provider, "example.com.")
+	// expect zone to have no records besides SOA and NS
+	// otherwise tests will fail (strict mode)
+	testSuite.ExpectEmptyZone = true
+	testSuite.RunTests(t)
+}


### PR DESCRIPTION
Fixes a cleanup bug in SRV and SVCB records in libdnstest, introduced in https://github.com/libdns/libdns/pull/189.

The bug slipped through because tests didn’t check for unknown leftovers, and the in-memory provider had no persistence to expose it.

The fix corrects cleanup logic and adds an optional strict mode: zones must be empty after operations. This is good for the in-memory provider. It’s not defaulted, since not everyone can dedicate a separate test zone (they cost about $6/year on AWS).