### PR TITLE
Another clarification about trailing dots

### DIFF
--- a/libdns.go
+++ b/libdns.go
@@ -261,6 +261,7 @@ type ZoneLister interface {
 
 // [Zone] is a generalized representation of a DNS zone.
 type Zone struct {
+	// Name is the fully qualified domain name of the zone, including the trailing dot (e.g., "example.com.")
 	Name string
 }
 

--- a/libdns.go
+++ b/libdns.go
@@ -303,6 +303,11 @@ func AbsoluteName(name, zone string) string {
 	if zone == "" {
 		return strings.Trim(name, ".")
 	}
+	if !strings.HasSuffix(zone, ".") {
+		// "zone" should always be a FQDN (with a trailing dot), but we don't
+		// enforce this anywhere, so we'll go ahead and correct it if needed.
+		zone += "."
+	}
 	if name == "" || name == "@" {
 		return zone
 	}

--- a/libdnstest/libdnstest.go
+++ b/libdnstest/libdnstest.go
@@ -136,6 +136,12 @@ func NewTestSuite(provider Provider, zone string) *TestSuite {
 
 // RunTests does zone cleanup and runs all tests
 func (ts *TestSuite) RunTests(t *testing.T) {
+	// Validate that zone parameter has trailing dot - required for proper DNS operations
+	// and consistency with libdns conventions
+	if !strings.HasSuffix(ts.zone, ".") {
+		t.Fatalf("zone argument for NewTestSuite must have a trailing dot (e.g., 'example.com.' not 'example.com'). Got: %q", ts.zone)
+	}
+
 	// validate that essential record types are not skipped
 	essentialTypes := []string{"TXT", "A", "CNAME"}
 	for _, rrType := range essentialTypes {


### PR DESCRIPTION
I hit a bug in a third-party provider caused by a missing trailing dot in the zone name. The zone was read from the environment along with the secret token, and without the dot everything broke. To make this obvious, I added a check so tests always expect dot-terminated zone names.

That leads to the real question about ZoneLister: do we require dot termination, or do we treat zone names as arbitrary strings? If a zone name can be something like a UUID, then checking for dots is meaningless, and the only real requirement is "non-empty". 

The tests today assume zone name is FQDN with dot termination, but if that's not the contract, I'll relax the check.

AbsoluteName is another inconsistency. It doesn't check for trailing dots at all. Options are: enforce with error, silently append, or leave it to the caller (current way). I haven't touched it, but my preference is to enforce consistency one way or the other.