### PR TITLE
Never return an error in `RR.Parse()`

### DIFF
--- a/record_test.go
+++ b/record_test.go
@@ -674,3 +674,51 @@ func TestRRDataZeroValues(t *testing.T) {
 		}
 	}
 }
+
+func TestRRParseErrorField(t *testing.T) {
+	for _, test := range []RR{
+		{
+			Name: "example.com",
+			TTL:  1 * time.Hour,
+			Type: "A",
+			Data: "invalid-ip-address",
+		},
+		{
+			Name: "example.com",
+			TTL:  1 * time.Hour,
+			Type: "CAA",
+			Data: "invalid-caa-data",
+		},
+		{
+			Name: "example.com",
+			TTL:  1 * time.Hour,
+			Type: "SVCB",
+			Data: "\"invalid-svcb-data",
+		},
+		{
+			Name: "example.com",
+			TTL:  1 * time.Hour,
+			Type: "MX",
+			Data: "not-a-number target.example.com.",
+		},
+		{
+			Name: "example.com",
+			TTL:  1 * time.Hour,
+			Type: "SRV",
+			Data: "invalid srv data",
+		},
+	} {
+		parsed, err := test.Parse()
+		if err != nil {
+			t.Fatalf("Parse() should never return an error, got: %v", err)
+		}
+
+		if parsedRR, ok := parsed.(RR); ok {
+			if parsedRR.Error == nil {
+				t.Fatalf("Expected parsing error to be stored in RR.Error, but it was nil.")
+			}
+		} else {
+			t.Fatalf("Expected parsed record to be of type RR on parsing failure, got: %T", parsed)
+		}
+	}
+}


### PR DESCRIPTION
This sounded like a good idea when we discussed this, but after writing out the code, I'm not so sure any more, since just throwing out the errors looks kinda ugly.

Maybe an alternative solution would be to add a special `ParseError` struct?

```go
// Parse returns a type-specific structure for this RR, if it is
// a known/supported type. Otherwise, it returns itself.
//
// Callers will typically want to type-assert (or use a type switch on)
// the return value to extract values or manipulate it.
//
// In the event of a parsing error, a special [ParseError] struct is returned,
// without indicating an error. This means that “err” will always be nil (the
// current signature is maintained for backwards compatibility).
func (r RR) Parse() (record Record, err error) {
	switch r.Type {
	case "A", "AAAA":
		record, err = r.toAddress()
	case "CAA":
		record, err = r.toCAA()
	case "CNAME":
		record, err = r.toCNAME()
	case "HTTPS", "SVCB":
		record, err = r.toServiceBinding()
	case "MX":
		record, err = r.toMX()
	case "NS":
		record, err = r.toNS()
	case "SRV":
		record, err = r.toSRV()
	case "TXT":
		record, err = r.toTXT()
	default:
		record = r
	}

	if err != nil {
		record, err = r.toParseError(err)
	}
	return
}

type ParseError struct {
	Name  string
	Type  string
	TTL   time.Duration
	Data  string
	Error error
}

func (c ParseError) RR() RR {
	return RR{
		Name: c.Name,
		TTL:  c.TTL,
		Type: c.Type,
		Data: c.Data,
	}
}

func (r RR) toParseError(err error) ParseError {
	return ParseError{
		Name:  r.Name,
		Type:  r.Type,
		TTL:   r.TTL,
		Data:  r.Data,
		Error: err,
	}
}
```

Seems kinda weird to define a specific error struct, but this way we aren't hiding the error message, but naïve implementations can freely ignore them and just treat them as opaque `RR`s.

See also #200.