### PR TITLE
Refer to `RR` docs for the `Address` struct

### DIFF
--- a/rrtypes.go
+++ b/rrtypes.go
@@ -17,6 +17,9 @@ import (
 // data field, these record types are combined for ease of
 // use in Go programs, which supports both address sizes,
 // to help simplify code.
+//
+// See the documentation for [RR] for details on the “Name” and “TTL”
+// fields.
 type Address struct {
 	Name string
 	TTL  time.Duration


### PR DESCRIPTION
godoc alphabetizes all identifiers, so even though `RR` comes before `Address` in the source, `Address` comes first in the generated docs. This means that users reading the documentation from top to bottom will miss the `RR` docs buried in the middle, so this commit adds a cross-reference to the `RR` docs from the first record struct (`Address`).

See also the comments on #208.