### PR TITLE
Fix validate escaped sequence

### DIFF
--- a/record.go
+++ b/record.go
@@ -533,7 +533,7 @@ func ParseSvcParams(input string) (SvcParams, error) {
 					sb.WriteRune(rune(decOctet))
 					escape = 0
 					continue
-				} else if (ch < 0x21 || ch > 0x2F) && (ch < 0x3A && ch > 0x7E) {
+				} else if ch < 0x21 || 0x7E < ch {
 					return nil, fmt.Errorf("illegal escape sequence %s", rawVal[escape:i])
 				}
 			}

--- a/record_test.go
+++ b/record_test.go
@@ -505,6 +505,10 @@ func TestParseSvcParams(t *testing.T) {
 				"escapes": {"abc"},
 			},
 		},
+		{
+			input:     `illegal=\©`,
+			shouldErr: true,
+		},
 	} {
 		actual, err := ParseSvcParams(test.input)
 		if err != nil && !test.shouldErr {


### PR DESCRIPTION
According **RFC 9460 Appendix A** the right condition should be 
`(ch < 0x21 || ch > 0x2F) && (ch < 0x3A || ch > 0x7E)`
but it is simplifed because the previous `if` contains check `('0' <= ch <= '9')` that equals to  `(0x2F < ch < 0x3A)`.

So I suggest use following comparison blocks:
```go
...
if ch >= '0' && ch <= '9' { // equals to 'ch > 0x2F && ch < 0x3A'
...
} else if ch < 0x21 || 0x7E < ch { // equals to '!(ch > 0x2F && ch < 0x3A) && (ch < 0x21 || ch > 0x2F) && (ch < 0x3A || ch > 0x7E) ' in that case
...
```